### PR TITLE
update to latest version of league/flysystem-azure-blob-storage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "require": {
         "silverstripe/framework": "^4.8",
         "silverstripe/vendor-plugin": "^1.0",
-        "league/flysystem-azure-blob-storage": "^1.0",
-        "league/flysystem-cached-adapter": "^1.0"
+        "league/flysystem-azure-blob-storage": "^3.3.0",
+        "league/flysystem-cached-adapter": "^1.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently the version of guzzle required in league/flysystem-azure-blob-storage 1.0.0 conflicts with the latest version of silverstripe/graphql